### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,24 @@
 
 [![Build Status](https://travis-ci.org/NLeSC/mcfly-tutorial.svg?branch=master)](https://travis-ci.org/NLeSC/mcfly-tutorial)
 
-This repository contains notebooks that show how to use the [mcfly](https://github.com/NLeSC/mcfly) software. Mcfly is deep learning tool for time series classification..
+This repository contains notebooks that show how to use the [mcfly](https://github.com/NLeSC/mcfly) software. Mcfly is a deep learning tool for time series classification.
 
 The tutorial can be found in the notebook [notebooks/tutorial/tutorial.ipynb](https://github.com/NLeSC/mcfly-tutorial/blob/master/notebooks/tutorial/tutorial.ipynb). This tutorial will let you train deep learning models with mcfly on the [PAMAP2 dataset for activity recognition](https://archive.ics.uci.edu/ml/datasets/PAMAP2+Physical+Activity+Monitoring).
 
 Prerequisites:
 - Python 2.7 or >3.5
 - Have the following python packages installed:
-  - mcfly
   - jupyter
- 
+  - mcfly
+
+## Installation jupyter
+The tutorials are provided in Jupyter notebooks, which can be found in the folder notebooks.
+To use a notebook, first install Jupyter, for instance through pypi:
+
+`pip install jupyter`
+
+This also installs other dependencies like Matplotlib and Numpy.
+For more documentation on Jupyter: See the [official documentation](https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/).
 
 ## Installation mcfly
 Mcfly can be installed through pypi:
@@ -22,13 +30,6 @@ Mcfly can be installed through pypi:
 
 See https://github.com/NLeSC/mcfly for alternative installation instructions
 
-## Installation jupyter
-The tutorials are provided in Jupyter notebooks, which can be found in the folder notebooks.
-To use a notebook, first install Jupyter:
-
-`pip install jupyter`
-
-For more documentation on Jupyter: See the [official documentation](https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/)
 
 ## Running the notebooks
 The tutorials can be run using Jupyter. From the tutorial root folder run:


### PR DESCRIPTION
Typo + reverse jupyter - mcfly order, since mcfly has many dependencies that are also installed as Jupyter dependencies, but people may not want to use pip to install all those things. For instance, I want to install stuff into a conda environment, using conda as much as possible and only using pip for mcfly.