### PR TITLE
Update test workflow and remove nose imports

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Python info
         run: |
           which python3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,8 +19,9 @@ jobs:
     name: first code check / python-3.10 / ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/checkout@v3
+        uses: actions/setup-python@v3
         with:
           python-version: 3.10
       - name: Python info
@@ -51,8 +52,9 @@ jobs:
           - python-version: 3.10
             os: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/checkout@v3
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python info

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,37 +4,38 @@
 name: CI Build
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+    - main
   pull_request:
-    types: [opened, reopened]
+    branches:
+    - main
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   first_check:
-    name: first code check / python-3.8 / ubuntu-latest
+    name: first code check / python-3.10 / ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/checkout@v3
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Python info
         run: |
-          which python
-          python --version
+          which python3
+          python3 --version
       - name: Install dependiencies
         run: |
-          python -m pip install --upgrade pip
-          pip install mcfly prospector nose pandas
-      - name: Show pip list
-        run: |
-          pip list
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install mcfly[dev] pandas
       - name: Check style against standards using prospector (only warn for now, but never fail)
         shell: bash -l {0}
         run: prospector --profile linter_profile -o grouped -o pylint:pylint-report.txt --zero-exit
       - name: Run unit tests
-        run: |
-          nosetests
+        run: pytest -v
           
   basic_checks:
     name: Run tests across OS and versions / python-${{ matrix.python-version }} / ${{ matrix.os }}
@@ -44,15 +45,14 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
           # already tested in first_check job
-          - python-version: 3.8
+          - python-version: 3.10
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/checkout@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python info
@@ -61,11 +61,7 @@ jobs:
           python --version
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install mcfly prospector nose pandas
-      - name: Show pip list
-        run: |
-          pip list
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install mcfly prospector pytest pandas
       - name: Run unit tests
-        run: |
-          nosetests
+        run: pytest -v

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependiencies
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install mcfly[dev] pandas
+          python3 -m pip install mcfly prospector pytest pandas
       - name: Check style against standards using prospector (only warn for now, but never fail)
         shell: bash -l {0}
         run: prospector --profile linter_profile -o grouped -o pylint:pylint-report.txt --zero-exit

--- a/tests/test_tutorial_pamap2.py
+++ b/tests/test_tutorial_pamap2.py
@@ -1,7 +1,6 @@
 from utils import tutorial_pamap2
 import numpy as np
 import pandas as pd
-from os import listdir
 import os.path
 import unittest
 

--- a/tests/test_tutorial_pamap2.py
+++ b/tests/test_tutorial_pamap2.py
@@ -1,7 +1,6 @@
 from utils import tutorial_pamap2
 import numpy as np
 import pandas as pd
-from nose.tools import assert_equal, assert_equals
 from os import listdir
 import os.path
 import unittest


### PR DESCRIPTION
Closes #49 

Updates the test workflow and runs the unit tests with `pytest` instead of `nose`. Also removes unused imports from the (removed) `nose` package in the test file.

The workflow is not run on Python 3.6 anymore but on 3.7 to 3.10.